### PR TITLE
Fix problem that error that can't be handled occurs

### DIFF
--- a/src/PacketDecoder.ts
+++ b/src/PacketDecoder.ts
@@ -27,7 +27,7 @@ export class PacketDecoder extends Writable {
 		});
 	}
 
-	public async _write(chunk: Buffer, _encoding: BufferEncoding, callback: () => void): Promise<void> {
+	public _write(chunk: Buffer, _encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
 		const {getPayload, decodeHandshake, decodePong} = this;
 		if (!this.packetInfo) {
 			this.packetInfo = this.decodeHeader(chunk);
@@ -40,7 +40,7 @@ export class PacketDecoder extends Writable {
 				return callback();
 			}
 			if (this.buffer.length > this.packetInfo.length) {
-				throw new Error('we did overrun expected data size!');
+				return callback(new Error('we did overrun expected data size!'));
 			}
 		}
 		try {


### PR DESCRIPTION
#12

- I fixed the problem by using `callback` function instead of `throw` expression to propagate error.
- [Node.js official documentation about _write function](https://nodejs.org/api/stream.html#writable_writechunk-encoding-callback)